### PR TITLE
Change Dockerfile to install ashlar from local files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN pip install -q -U pip
 RUN pip install -q numpy
 RUN pip install -q scipy
 RUN pip install -q cython
-RUN pip install ashlar
+
+COPY / /app/ashlar/
+RUN pip install /app/ashlar
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 ENV OMP_NUM_THREADS 1


### PR DESCRIPTION
Previously it installed from pypi, but this meant one could only build
the latest deployed version and not github tags or branches.