### PR TITLE
add channel_maps as metadata parameter to Bioformatsreader

### DIFF
--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -252,6 +252,17 @@ class BioformatsMetadata(PlateMetadata):
     @property
     def num_channels(self):
         return self._metadata.getChannelCount(0)
+    
+    @property
+    def channel_map(self):
+        n_channels = self._metadata.getChannelCount(0)
+        channel_names = []
+        
+        for id in range(n_channels):
+            channel_names.append(self._metadata.getChannelName(0, id))
+        channel_map = dict(zip(list(range(n_channels)), channel_names))
+    
+        return channel_map
 
     @property
     def num_plates(self):
@@ -391,7 +402,7 @@ class BioformatsMetadata(PlateMetadata):
             v = method(i).value
             values.append(v)
         return np.array(values, dtype=int)
-
+ 
 
 class BioformatsReader(PlateReader):
 


### PR DESCRIPTION
I frequently use the ashlar python API to stitch my individual tif images using the FilePatternReader. I recently also started using .nd2 files. When adapting my workflow to utilise the BioformatsReader I discovered that it currently does not have the .metadata.channel_map property implemented in the FilePatternReader. 

I added it to allow users to also access channel names when utilising the python API. For me this makes my workflow easily adaptable to many different bio format types. 

Let me know if there is anything else I should do :) 