### PR TITLE
Added command line options to swap axes, disable interpolation, and output tile positions as a csv

### DIFF
--- a/ashlar/reg.py
+++ b/ashlar/reg.py
@@ -1038,7 +1038,7 @@ class Mosaic(object):
     def __init__(
         self, aligner, shape, channels=None, ffp_path=None, dfp_path=None,
         flip_mosaic_x=False, flip_mosaic_y=False, barrel_correction=None,
-        pastefunc = utils.pastefunc_blend, verbose=False
+        pastefunc = utils.pastefunc_blend, subpixel_shift=True, verbose=False
     ):
         self.aligner = aligner
         self.shape = tuple(shape)
@@ -1050,6 +1050,7 @@ class Mosaic(object):
         self._load_correction_profiles(dfp_path, ffp_path)
         self.verbose = verbose
         self.pastefunc = pastefunc
+        self.subpixel_shift = subpixel_shift
 
     def _sanitize_channels(self, channels):
         all_channels = range(self.aligner.metadata.num_channels)
@@ -1150,7 +1151,8 @@ class Mosaic(object):
                 sys.stdout.flush()
             img = self.aligner.reader.read(c=channel, series=si)
             img = self.correct_illumination(img, channel)
-            utils.paste(out, img, position, func=self.pastefunc)
+            utils.paste(out, img, position, func=self.pastefunc,
+                    subpixel_shift=self.subpixel_shift)
         # Memory-conserving axis flips.
         if self.flip_mosaic_x:
             for i in range(len(out)):

--- a/ashlar/scripts/ashlar.py
+++ b/ashlar/scripts/ashlar.py
@@ -230,6 +230,7 @@ def main(argv=sys.argv):
         mosaic_args['verbose'] = True
     mosaic_args['flip_mosaic_x'] = args.flip_mosaic_x
     mosaic_args['flip_mosaic_y'] = args.flip_mosaic_y
+    mosaic_args['subpixel_shift'] = not args.no_resample
 
     try:
         if args.plates:


### PR DESCRIPTION
I've been using ashlar for a bit to stitch various image sets, and it has worked great, thanks for making this package! In dealing with some weird nd2 files and tile patterns, I ended up adding a couple command line flags, and I figured I would see if you guys think they would be worth merging in.

The options I added are:
`--transpose`, which swaps the x and y axes of the input tile positions. I had this happen before the flip x and y flags happen, but it could also happen after, depending on what you think is best.
`--no-resample`, which disables shifting images to a fractional pixel location and instead rounds the position to the nearest integer. In my case I had small features that were getting somewhat blurred by the shifting and so I wanted to disable it, but I imagine it also saves on processing time when combining images.
`--output-positions`, which instead of saving an output image saves the aligned positions of each tile to a csv file. I wasn't sure the best way for this to work with the output flag, right now no images are saved even if the `-o` flag is specified. It would probably be better to issue an error if both are specified, or generate both.

Let me know what you guys think of these additions,